### PR TITLE
Gazebo and ros_control URDF Tags

### DIFF
--- a/baxter_description/urdf/baxter.urdf
+++ b/baxter_description/urdf/baxter.urdf
@@ -1214,7 +1214,6 @@
   <gazebo>
     <plugin name="ros_control" filename="libgazebo_ros_control.so">
       <robotNamespace>/baxter</robotNamespace>
-      <!--controlPeriod>1</controlPeriod-->
     </plugin>
   </gazebo>
 


### PR DESCRIPTION
Changes:
- Remove the inertial tag for the base link to fix the KDL warning: "The root link base has an inertia specified in the URDF, but KDL does not support a root link with an inertia. As a workaround, you can add an extra dummy link to your URDF."
- Add transmission tags for all of Baxter's joints - adds compatibility with ros_control and the Gazebo controllers
- Add the ros_control plugin for Gazebo
- Turn on collision checking between Baxter's torso and all other links in Gazebo
