### PR TITLE
Gazebo and ros_control URDF Tags

### DIFF
--- a/baxter_description/urdf/baxter.urdf
+++ b/baxter_description/urdf/baxter.urdf
@@ -1218,7 +1218,7 @@
   </gazebo>
 
   <gazebo reference="torso">
-    <selfCollide>true</selfCollide>
+    <selfCollide>false</selfCollide>
   </gazebo>
 
 </robot>


### PR DESCRIPTION
Changes:
- Remove the inertial tag for the base link to fix the KDL warning: "The root link base has an inertia specified in the URDF, but KDL does not support a root link with an inertia. As a workaround, you can add an extra dummy link to your URDF."
- Add transmission tags for all of Baxter's joints - adds compatibility with ros_control and the Gazebo controllers
- Add the ros_control plugin for Gazebo
- Turn on collision checking between Baxter's torso and all other links in Gazebo
