### PR TITLE
The maximum effort for s1 joint is increased to 100

### DIFF
--- a/baxter_description/urdf/baxter.urdf
+++ b/baxter_description/urdf/baxter.urdf
@@ -640,7 +640,7 @@
     <axis xyz="0 0 1"/>
     <parent link="right_upper_shoulder"/>
     <child link="right_lower_shoulder"/>
-    <limit effort="50.0" lower="-2.147" upper="1.047" velocity="1.5"/>
+    <limit effort="100.0" lower="-2.147" upper="1.047" velocity="1.5"/>
     <dynamics damping="0.7" friction="0.0"/>
   </joint>
   <joint name="right_e0" type="revolute">
@@ -1083,7 +1083,7 @@
     <axis xyz="0 0 1"/>
     <parent link="left_upper_shoulder"/>
     <child link="left_lower_shoulder"/>
-    <limit effort="50.0" lower="-2.147" upper="1.047" velocity="1.5"/>
+    <limit effort="100.0" lower="-2.147" upper="1.047" velocity="1.5"/>
     <dynamics damping="0.7" friction="0.0"/>
   </joint>
   <joint name="left_e0" type="revolute">


### PR DESCRIPTION
The maximum effort for the s1 joints were 50Nm in the URDF. Since there is no spring compensation in the simulator the maximum effort is more than 50Nm and hence it is updated as 100Nm in the URDF
