### PR TITLE
Adds meshes and URDF to baxter_description installations

### DIFF
--- a/baxter_description/CMakeLists.txt
+++ b/baxter_description/CMakeLists.txt
@@ -4,3 +4,8 @@ project(baxter_description)
 find_package(catkin REQUIRED)
 
 catkin_package()
+
+foreach(dir meshes urdf)
+   install(DIRECTORY ${dir}/
+      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
+endforeach(dir)


### PR DESCRIPTION
Debian installations were previously missing URDF and meshes. This diff installs meshes and the URDF.
