### PR TITLE
Re baxter_sim #66 by adding mass to null_gripper

### DIFF
--- a/rethink_ee_description/urdf/null_gripper/null_gripper.xacro
+++ b/rethink_ee_description/urdf/null_gripper/null_gripper.xacro
@@ -7,14 +7,14 @@
   <link name="${side}_gripper_base">
     <inertial>
       <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
-      <mass value="0.0"/>
+      <mass value="0.0001"/>
       <inertia ixx="1e-08" ixy="0" ixz="0" iyy="1e-08" iyz="0" izz="1e-08"/>
     </inertial>
   </link>
   <link name="${side}_gripper">
     <inertial>
       <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
-      <mass value="0.0"/>
+      <mass value="0.0001"/>
       <inertia ixx="1e-08" ixy="0" ixz="0" iyy="1e-08" iyz="0" izz="1e-08"/>
     </inertial>
   </link>


### PR DESCRIPTION
When using the null gripper in Gazebo, the robot
would fail to load, instead showing just pieces
of Baxter on the ground. This was due to the
<side>_gripper_base and <side>_gripper links
having no mass at all, which I assume messes up
intertial calculations. By adding a nominal mass
of 0.0001, the [-nan -nan -nan] pose issue is
resolved.

https://github.com/RethinkRobotics/baxter_simulator/issues/66