### PR TITLE
Specify API doc location.

### DIFF
--- a/baxter_core_msgs/package.xml
+++ b/baxter_core_msgs/package.xml
@@ -12,6 +12,7 @@
   </maintainer>
   <license>BSD</license>
   <url type="website">http://sdk.rethinkrobotics.com</url>
+  <url type="website">http://api.rethinkrobotics.com/baxter_core_msgs/html/index-msg.html</url>
   <url type="repository">
     https://github.com/RethinkRobotics/baxter_common
   </url>

--- a/baxter_maintenance_msgs/package.xml
+++ b/baxter_maintenance_msgs/package.xml
@@ -12,6 +12,7 @@
   </maintainer>
   <license>BSD</license>
   <url type="website">http://sdk.rethinkrobotics.com</url>
+  <url type="website">http://api.rethinkrobotics.com/baxter_maintenance_msgs/html/index-msg.html</url>
   <url type="repository">
     https://github.com/RethinkRobotics/baxter_common
   </url>


### PR DESCRIPTION
This helps people who initially visit ROS wiki pages of each package to find the actual API page easily.