### PR TITLE
(kinetic) Makes Baxter's electric grippers URDF optional

### DIFF
--- a/baxter_description/urdf/baxter.urdf.xacro
+++ b/baxter_description/urdf/baxter.urdf.xacro
@@ -3,6 +3,8 @@
 
   <xacro:arg name="gazebo" default="false"/>
   <xacro:arg name="pedestal" default="true"/>
+  <xacro:arg name="right_electric_gripper" default="true"/>
+  <xacro:arg name="left_electric_gripper" default="true"/>
   <!-- Baxter Base URDF -->
   <xacro:include filename="$(find baxter_description)/urdf/baxter_base/baxter_base.urdf.xacro">
     <xacro:arg name="gazebo" value="${gazebo}"/>
@@ -16,9 +18,13 @@
   </xacro:if>
 
   <!-- Left End Effector -->
-  <xacro:include filename="$(find baxter_description)/urdf/left_end_effector.urdf.xacro" />
+  <xacro:include filename="$(find baxter_description)/urdf/left_end_effector.urdf.xacro">
+      <xacro:arg name="left_electric_gripper" value="${left_electric_gripper}"/>
+  </xacro:include>
 
   <!-- Right End Effector -->
-  <xacro:include filename="$(find baxter_description)/urdf/right_end_effector.urdf.xacro" />
+  <xacro:include filename="$(find baxter_description)/urdf/right_end_effector.urdf.xacro">
+      <xacro:arg name="right_electric_gripper" value="${right_electric_gripper}"/>
+  </xacro:include>
 
 </robot>

--- a/baxter_description/urdf/left_end_effector.urdf.xacro
+++ b/baxter_description/urdf/left_end_effector.urdf.xacro
@@ -1,13 +1,21 @@
 <?xml version="1.0" ?>
 <robot name="left_end_effector" xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:include filename="$(find rethink_ee_description)/urdf/electric_gripper/rethink_electric_gripper.xacro" />
-  <xacro:rethink_electric_gripper side="left"
-                                  l_finger="extended_narrow"
-                                  l_finger_slot="2"
-                                  l_finger_tip="paddle_tip"
-                                  l_finger_grasp="inner"
-                                  r_finger="extended_narrow"
-                                  r_finger_slot="2"
-                                  r_finger_tip="paddle_tip"
-                                  r_finger_grasp="inner"/>
+  <xacro:arg name="left_electric_gripper" default="true"/>
+  <xacro:if value="$(arg left_electric_gripper)">
+    <xacro:include filename="$(find rethink_ee_description)/urdf/electric_gripper/rethink_electric_gripper.xacro" />
+    <xacro:rethink_electric_gripper side="left"
+                                    l_finger="extended_narrow"
+                                    l_finger_slot="2"
+                                    l_finger_tip="paddle_tip"
+                                    l_finger_grasp="inner"
+                                    r_finger="extended_narrow"
+                                    r_finger_slot="2"
+                                    r_finger_tip="paddle_tip"
+                                    r_finger_grasp="inner"/>
+  </xacro:if>
+  <xacro:unless value="$(arg left_electric_gripper)">
+    <xacro:include filename="$(find rethink_ee_description)/urdf/null_gripper/null_gripper.xacro" />
+    <xacro:null_gripper side="left"/>
+  </xacro:unless>
+
 </robot>

--- a/baxter_description/urdf/right_end_effector.urdf.xacro
+++ b/baxter_description/urdf/right_end_effector.urdf.xacro
@@ -1,13 +1,20 @@
 <?xml version="1.0" ?>
 <robot name="right_end_effector" xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:include filename="$(find rethink_ee_description)/urdf/electric_gripper/rethink_electric_gripper.xacro" />
-  <xacro:rethink_electric_gripper side="right"
-                                  l_finger="extended_narrow"
-                                  l_finger_slot="2"
-                                  l_finger_tip="half_round_tip"
-                                  l_finger_grasp="inner"
-                                  r_finger="extended_narrow"
-                                  r_finger_slot="2"
-                                  r_finger_tip="half_round_tip"
-                                  r_finger_grasp="inner"/>
+  <xacro:arg name="right_electric_gripper" default="true"/>
+  <xacro:if value="$(arg right_electric_gripper)">
+    <xacro:include filename="$(find rethink_ee_description)/urdf/electric_gripper/rethink_electric_gripper.xacro" />
+    <xacro:rethink_electric_gripper side="right"
+                                    l_finger="standard_narrow"
+                                    l_finger_slot="1"
+                                    l_finger_tip="basic_hard_tip"
+                                    l_finger_grasp="inner"
+                                    r_finger="standard_narrow"
+                                    r_finger_slot="1"
+                                    r_finger_tip="basic_hard_tip"
+                                    r_finger_grasp="inner"/>
+  </xacro:if>
+  <xacro:unless value="$(arg right_electric_gripper)">
+  <xacro:include filename="$(find rethink_ee_description)/urdf/null_gripper/null_gripper.xacro" />
+    <xacro:null_gripper side="right"/>
+  </xacro:unless>
 </robot>


### PR DESCRIPTION
This makes the electric grippers (both left and right)
optional when constructing Baxter's xacro files. The
electric grippers will default to "true" but can be explicitly
removed programmatically via arguments to xacro:
```
$ rosrun xacro xacro --inorder \
         `rospack find baxter_description`/urdf/baxter.urdf.xacro \
          left_electric_gripper:=false \
          right_electric_gripper:=false
```
(cherry picked from commit 84f2291227af9b85a75d52adfd0208b14e54722d)

This is the kinetic version of #90